### PR TITLE
Adding writing of coordinates and time to CSV files

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -2,13 +2,10 @@ include("constitutive.jl")
 include("interpolation.jl")
 include("ics_bcs.jl")
 
-global sim_id = Ref{Int64}(1); 
-
 function SolidMechanics(params::Dict{Any,Any})
     input_mesh = params["input_mesh"]
     model_params = params["model"]
     coords = read_coordinates(input_mesh)
-    write_coords_csv(params, coords) 
     num_nodes = Exodus.num_nodes(input_mesh.init)
     reference = Matrix{Float64}(undef, 3, num_nodes)
     current = Matrix{Float64}(undef, 3, num_nodes)
@@ -103,7 +100,6 @@ function HeatConduction(params::Dict{Any,Any})
     input_mesh = params["input_mesh"]
     model_params = params["model"]
     coords = read_coordinates(input_mesh)
-    write_coords_csv(params, coords) 
     num_nodes = Exodus.num_nodes(input_mesh.init)
     reference = Matrix{Float64}(undef, 3, num_nodes)
     temperature = Vector{Float64}(undef, num_nodes)
@@ -181,16 +177,6 @@ function HeatConduction(params::Dict{Any,Any})
         time,
         failed,
     )
-end
-
-function write_coords_csv(params::Dict{Any,Any}, coords::Matrix{Float64})
-  csv_interval = get(params, "CSV output interval", 0)
-  if csv_interval > 0
-    sim_id_string = string(sim_id[], pad = 2) * "-"
-    coord_filename = sim_id_string * "coords.csv"
-    writedlm(coord_filename, coords, '\n')
-    sim_id[] = sim_id[] + 1; 
-  end 
 end
 
 function create_model(params::Dict{Any,Any})

--- a/src/model.jl
+++ b/src/model.jl
@@ -184,7 +184,12 @@ end
 function write_coords_csv(params::Dict{Any,Any}, coords::Matrix{Float64})
   csv_interval = get(params, "CSV output interval", 0)
   if csv_interval > 0
-    coord_filename = "coords.csv" 
+    sim_id = 1
+    if haskey(params, "global_simulation") == true
+      sim_id = params["global_simulation"].subsim_name_index_map[params["name"]]
+    end
+    sim_id_string = string(sim_id, pad = 2) * "-"
+    coord_filename = sim_id_string * "coords.csv"
     writedlm(coord_filename, coords, '\n')
   end 
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -2,6 +2,8 @@ include("constitutive.jl")
 include("interpolation.jl")
 include("ics_bcs.jl")
 
+global sim_id = Ref{Int64}(1); 
+
 function SolidMechanics(params::Dict{Any,Any})
     input_mesh = params["input_mesh"]
     model_params = params["model"]
@@ -184,13 +186,10 @@ end
 function write_coords_csv(params::Dict{Any,Any}, coords::Matrix{Float64})
   csv_interval = get(params, "CSV output interval", 0)
   if csv_interval > 0
-    sim_id = 1
-    if haskey(params, "global_simulation") == true
-      sim_id = params["global_simulation"].subsim_name_index_map[params["name"]]
-    end
-    sim_id_string = string(sim_id, pad = 2) * "-"
+    sim_id_string = string(sim_id[], pad = 2) * "-"
     coord_filename = sim_id_string * "coords.csv"
     writedlm(coord_filename, coords, '\n')
+    sim_id[] = sim_id[] + 1; 
   end 
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -6,6 +6,7 @@ function SolidMechanics(params::Dict{Any,Any})
     input_mesh = params["input_mesh"]
     model_params = params["model"]
     coords = read_coordinates(input_mesh)
+    write_coords_csv(params, coords) 
     num_nodes = Exodus.num_nodes(input_mesh.init)
     reference = Matrix{Float64}(undef, 3, num_nodes)
     current = Matrix{Float64}(undef, 3, num_nodes)
@@ -100,6 +101,7 @@ function HeatConduction(params::Dict{Any,Any})
     input_mesh = params["input_mesh"]
     model_params = params["model"]
     coords = read_coordinates(input_mesh)
+    write_coords_csv(params, coords) 
     num_nodes = Exodus.num_nodes(input_mesh.init)
     reference = Matrix{Float64}(undef, 3, num_nodes)
     temperature = Vector{Float64}(undef, num_nodes)
@@ -177,6 +179,14 @@ function HeatConduction(params::Dict{Any,Any})
         time,
         failed,
     )
+end
+
+function write_coords_csv(params::Dict{Any,Any}, coords::Matrix{Float64})
+  csv_interval = get(params, "CSV output interval", 0)
+  if csv_interval > 0
+    coord_filename = "coords.csv" 
+    writedlm(coord_filename, coords, '\n')
+  end 
 end
 
 function create_model(params::Dict{Any,Any})

--- a/src/time_integrator.jl
+++ b/src/time_integrator.jl
@@ -485,7 +485,6 @@ function writedlm_nodal_array(filename::String, nodal_array::Matrix{Float64})
     end
 end
 
-
 function write_step(params::Dict{Any,Any}, integrator::Any, model::Any)
     stop = integrator.stop
     exodus_interval = get(params, "Exodus output interval", 1)
@@ -502,7 +501,7 @@ function write_step(params::Dict{Any,Any}, integrator::Any, model::Any)
     end
 end
 
-function write_step_csv(integrator::StaticTimeIntegrator, model::Any, sim_id::Integer)
+function write_step_csv(integrator::StaticTimeIntegrator, model::SolidMechanics, sim_id::Integer)
     stop = integrator.stop
     index_string = "-" * string(stop, pad = 4)
     sim_id_string = string(sim_id, pad = 2) * "-"
@@ -518,7 +517,7 @@ function write_step_csv(integrator::StaticTimeIntegrator, model::Any, sim_id::In
     end
 end
 
-function write_step_csv(integrator::DynamicTimeIntegrator, model::Any, sim_id::Integer)
+function write_step_csv(integrator::DynamicTimeIntegrator, model::SolidMechanics, sim_id::Integer)
     stop = integrator.stop
     index_string = "-" * string(stop, pad = 4)
     sim_id_string = string(sim_id, pad = 2) * "-"


### PR DESCRIPTION
The writing happens in time_integrator.jl in the existing write_csv routines.  The coords printed are interleaved just like disp, velo and acce.  time is printed at each time-step and for each subdomain, since the subdomains could be using different dts.  