### PR TITLE
Seth-Hill energy

### DIFF
--- a/src/constitutive.jl
+++ b/src/constitutive.jl
@@ -594,7 +594,7 @@ function constitutive(material::SethHill, F::Matrix{Float64})
     Wshear = material.μ / 4 / material.n^2 * (trCbar²ⁿ + trCbar⁻²ⁿ - 2 * trCbarⁿ  - 2 * trCbar⁻ⁿ + 6)
     W = Wbulk + Wshear
     Pbulk = material.κ / 2 / material.m * (J²ᵐ - Jᵐ - J⁻²ᵐ + J⁻ᵐ) * F⁻ᵀ
-    Pshear = material.μ / 4 / material.n * (4/3 * (-trCbar²ⁿ + trCbarⁿ + trCbar⁻²ⁿ - trCbar⁻ⁿ) * F⁻ᵀ + 2 * F⁻ᵀ * (Cbar²ⁿ - Cbarⁿ - Cbar⁻²ⁿ + Cbar⁻ⁿ))
+    Pshear = material.μ / material.n * (1/3 * (-trCbar²ⁿ + trCbarⁿ + trCbar⁻²ⁿ - trCbar⁻ⁿ) * F⁻ᵀ + F⁻ᵀ * (Cbar²ⁿ - Cbarⁿ - Cbar⁻²ⁿ + Cbar⁻ⁿ))
     P = Pbulk + Pshear
     AA = zeros(3, 3, 3, 3)
     return W, P, AA

--- a/test/constitutive-model-energy-gradient.jl
+++ b/test/constitutive-model-energy-gradient.jl
@@ -1,0 +1,43 @@
+using Random
+
+include("../src/minitensor.jl")
+include("../src/constitutive_def.jl")
+include("../src/constitutive.jl")
+
+function finite_difference(material::Solid, F::Matrix{Float64}, dF::Matrix{Float64}, h::Float64)
+    return (constitutive(material, F - 2*h*dF)[1] - 8*constitutive(material, F - h*dF)[1] + 8*constitutive(material, F + h*dF)[1] - constitutive(material, F + 2*h*dF)[1]) / (12*h)
+end
+
+
+@testset "constitutive-model-energy-gradient" begin
+    Random.seed!(0)
+
+    base_params = Dict{Any, Any}(
+          "elastic modulus" => 1.0,
+          "Poisson's ratio" => 0.3,
+          "density" => 1.0,
+    )
+    sh_params = merge(base_params, Dict{Any, Any}(
+          "m" => 2,
+          "n" => 2,
+         ))
+    models = [
+              Neohookean(base_params),
+              SaintVenant_Kirchhoff(base_params),
+              SethHill(sh_params),
+             ]
+    F_n = 10
+    dF_n = 10
+
+    for model in models
+        for _ in 1:F_n
+            F = Random.randn(3, 3) * 0.1 + I
+            dWdF = constitutive(model, F)[2]
+            for _ in 1:dF_n
+                dF = Random.randn(3, 3) * 0.1
+                dWdF_fd = finite_difference(model, F, dF, 1e-6)
+                @test isapprox(sum(dWdF .* dF), dWdF_fd, atol=1e-6)
+            end
+        end
+    end
+end


### PR DESCRIPTION
- Implement a hyperelastic constitutive model with a strain energy formulation based on the Seth-Hill family of strain tensors
- Add a test for verifying via finite difference computations that the stress tensor and energy value output by hyperelastic constitutive models are consistent